### PR TITLE
[Build] Ensure installation of development requirements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ build:
 
 install:
 	pip install -e .
+	pip install -r requirements-dev.txt
 
 lint:
 	ruff check src tests


### PR DESCRIPTION
Add installation of `requirements-dev.txt` to the build process to ensure all development dependencies are installed.