### PR TITLE
[CI] Update PyPI URL in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: pypi
-      url: https://pypi.org/p/<your-pypi-project-name>
+      url: https://pypi.org/p/dowhen
     permissions:
       id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
     steps:


### PR DESCRIPTION
This fix the broken url at https://github.com/gaogaotiantian/dowhen/deployments/pypi