### PR TITLE
add offset to goto

### DIFF
--- a/src/dowhen/callback.py
+++ b/src/dowhen/callback.py
@@ -88,7 +88,7 @@ class Callback:
             raise ValueError(
                 f"Multiple line numbers found for target '{target}': {line_numbers}"
             )
-        line_number = line_numbers[0]
+        line_number = line_numbers[0] + self.kwargs["offset"]
         with warnings.catch_warnings():
             # This gives a RuntimeWarning in Python 3.12
             warnings.simplefilter("ignore", RuntimeWarning)
@@ -100,8 +100,8 @@ class Callback:
         return cls(func)
 
     @classmethod
-    def goto(cls, target: str | int) -> Callback:
-        return cls("goto", target=target)
+    def goto(cls, target: str | int, offset: int = 0) -> Callback:
+        return cls("goto", target=target, offset=offset)
 
     @classmethod
     def bp(cls) -> Callback:

--- a/src/dowhen/handler.py
+++ b/src/dowhen/handler.py
@@ -74,8 +74,8 @@ class EventHandler:
         self.callbacks.append(Callback.do(func))
         return self
 
-    def goto(self, target: str | int) -> "EventHandler":
+    def goto(self, target: str | int, offset: int = 0) -> "EventHandler":
         from .callback import Callback
 
-        self.callbacks.append(Callback.goto(target))
+        self.callbacks.append(Callback.goto(target, offset))
         return self


### PR DESCRIPTION
类似执行类似这样的代码时

```python
from dowhen import do

def get_data():
    raise ValueError("no data")

def func():
    print("func is running")
    data = get_data()
    ...
    print(data)
    print("func is done")

try:
    func()
except ValueError:
    with do("data = 42").when(func, "+1").goto("data = get_data()", offset=1):
        func()
```
类似这样。我关注的是 `data = get_data()` 这行代码，但是实际上我需要定位的是下一行

