### PR TITLE
fix: disable global events with relative line identifiers

### DIFF
--- a/src/dowhen/trigger.py
+++ b/src/dowhen/trigger.py
@@ -128,23 +128,25 @@ class Trigger:
         # Relative identifiers like "+1" depend on a specific code context to calculate offsets,
         # but global events apply across all code objects, making the behavior unpredictable.
         if entity is None:
-            def is_relative_identifier(ident: str) -> None:
+
+            def is_relative_identifier(ident: str | int | re.Pattern) -> bool:
                 return (
                     isinstance(ident, str)
                     and ident.startswith("+")
                     and ident[1:].isdigit()
                 )
+
             err_msg = (
                 "Relative line identifier '{identifier}' cannot be used with global events (entity=None). "
                 "Relative identifiers are only valid for specific code objects."
             )
             for identifier in identifiers:
-                if is_relative_identifier(identifier):
-                    raise TypeError(err_msg.format(identifier=identifier))
-                elif isinstance(identifier, tuple):
+                if isinstance(identifier, tuple):
                     for sub_ident in identifier:
                         if is_relative_identifier(sub_ident):
                             raise TypeError(err_msg.format(identifier=sub_ident))
+                elif is_relative_identifier(identifier):
+                    raise TypeError(err_msg.format(identifier=identifier))
 
         events = []
 

--- a/tests/test_trigger.py
+++ b/tests/test_trigger.py
@@ -253,6 +253,23 @@ def test_global_events():
     assert events == [0, 0, 0]
 
 
+def test_global_events_with_relative_identifiers():
+    # Single relative identifier should raise ValueError
+    with pytest.raises(TypeError):
+        dowhen.when(None, "+1")
+
+    with pytest.raises(TypeError):
+        dowhen.when(None, "+5")
+
+    # Relative identifier in tuple should also raise ValueError
+    with pytest.raises(TypeError):
+        dowhen.when(None, ("some_code", "+2"))
+
+    # Multiple identifiers with one being relative should raise ValueError
+    with pytest.raises(TypeError):
+        dowhen.when(None, "some_code", "+3")
+
+
 def test_goto():
     def f():
         x = 0


### PR DESCRIPTION
Fix #69

Prevent the use of relative line identifiers with global events to avoid unpredictable behavior. Add tests to ensure that using relative identifiers raises appropriate errors.