### PR TITLE
fix: Compatible with Cython compiled function

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -12,6 +12,7 @@ coverage
 pytest
 pytest-cov
 coredumpy
+cython
 
 # Documentation requirements
 sphinx>=8.0

--- a/src/dowhen/callback.py
+++ b/src/dowhen/callback.py
@@ -26,9 +26,7 @@ class Callback:
     def __init__(self, func: str | Callable, **kwargs):
         if isinstance(func, str):
             pass
-        elif inspect.isfunction(func):
-            self.func_args = inspect.getfullargspec(func).args
-        elif inspect.ismethod(func):
+        elif callable(func):
             self.func_args = inspect.getfullargspec(func).args
         else:
             raise TypeError(f"Unsupported callback type: {type(func)}. ")
@@ -42,7 +40,7 @@ class Callback:
                 self._call_goto(frame)
             else:
                 self._call_code(frame)
-        elif inspect.isfunction(self.func) or inspect.ismethod(self.func):
+        elif callable(self.func):
             ret = self._call_function(frame, **kwargs)
         else:  # pragma: no cover
             assert False, "Unknown callback type"
@@ -60,7 +58,7 @@ class Callback:
         exec(self.func, frame.f_globals, frame.f_locals)
 
     def _call_function(self, frame: FrameType, **kwargs) -> Any:
-        assert isinstance(self.func, (FunctionType, MethodType))
+        assert callable(self.func)
         writeback = call_in_frame(self.func, frame, **kwargs)
 
         f_locals = frame.f_locals

--- a/tests/test_callback.py
+++ b/tests/test_callback.py
@@ -2,6 +2,9 @@
 # For details: https://github.com/gaogaotiantian/dowhen/blob/master/NOTICE
 
 
+import glob
+import importlib.util
+import subprocess
 import sys
 
 import pytest
@@ -237,3 +240,81 @@ def test_bp():
         assert "(Pdb) " in out
         assert "test_bp()" in out
         assert "return x" in out
+
+
+def import_from_path(module_name, file_path):
+    spec = importlib.util.spec_from_file_location(module_name, file_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_do_when_with_cython_function(tmpdir):
+    (tmpdir / "change.py").write("""def change(x, y):
+    x = 2
+    y = 3
+    return {"x": x, "y": y}
+""")
+    (tmpdir / "setup.py").write("""from Cython.Build import cythonize
+from setuptools import setup
+
+setup(ext_modules=cythonize("change.py"))
+""")
+
+    subprocess.check_call(
+        [sys.executable, "setup.py", "build_ext", "--inplace"], cwd=tmpdir
+    )
+    if sys.platform == "win32":
+        compiled_change = glob.glob(str(tmpdir / "change.*.pyd"))[0]
+    else:
+        compiled_change = glob.glob(str(tmpdir / "change.*.so"))[0]
+
+    change = import_from_path("change", compiled_change).change
+
+    def f(x, y):
+        return x + y
+
+    dowhen.do(change).when(f, "return x + y")
+    assert f(1, 1) == 5
+
+
+def test_do_when_with_cython_method(tmpdir):
+    (tmpdir / "A.py").write("""class A:
+    def change(self, x):
+        return {"x": 1}
+
+    @classmethod
+    def classmethod_change(cls, x):
+        return {"x": 2}
+
+    @staticmethod
+    def staticmethod_change(x):
+        return {"x": 3}
+""")
+    (tmpdir / "setup.py").write("""from Cython.Build import cythonize
+from setuptools import setup
+
+setup(ext_modules=cythonize("A.py"))
+""")
+
+    subprocess.check_call(
+        [sys.executable, "setup.py", "build_ext", "--inplace"], cwd=tmpdir
+    )
+    if sys.platform == "win32":
+        compiled_change = glob.glob(str(tmpdir / "A.*.pyd"))[0]
+    else:
+        compiled_change = glob.glob(str(tmpdir / "A.*.so"))[0]
+
+    A = import_from_path("A", compiled_change).A
+
+    def f(x):
+        return x
+
+    with dowhen.do(A().change).when(f, "return x"):
+        assert f(2) == 1
+
+    with dowhen.do(A.classmethod_change).when(f, "return x"):
+        assert f(3) == 2
+
+    with dowhen.do(A.staticmethod_change).when(f, "return x"):
+        assert f(4) == 3


### PR DESCRIPTION
When func is compiled using Cython, both `inspect.isfunction` and `inspect.ismethod` will return false. Therefore, when using the Callback constructor, an exception will be thrown directly: `Unsupported callback type: {type(func)}. `

```
Traceback (most recent call last):
  File "<input>", line 1, in <module>
  File "/home/chuck/xxxx/.venv/lib/python3.12/site-packages/dowhen/callback.py", line 33, in __init__
    raise TypeError(f"Unsupported callback type: {type(func)}. ")
TypeError: Unsupported callback type: <class '_cython_3_1_4.cython_function_or_method'>. 
```

Considering that the function compiled by Cython is a valid callable object, and `inspect.getfullargspec` can also correctly retrieve its parameters. We can directly modify `inspect.isfunction` and `inspect.ismethod` to `callable`  to solve this problem.
